### PR TITLE
Show nice list of available keys

### DIFF
--- a/web-extension/background.js
+++ b/web-extension/background.js
@@ -1,8 +1,14 @@
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-  chrome.runtime.sendNativeMessage(
-    'de.nilsalex.yktotp',
-    { account: message },
-    (response) => sendResponse(response),
-  );
-  return true;
+    const nativeMessage = {
+        request: message.type,
+        account: message.type === "getOtp" ? message.key : ""
+    };
+
+    chrome.runtime.sendNativeMessage(
+        'de.nilsalex.yktotp',
+        nativeMessage,
+        sendResponse,
+    );
+
+    return true;
 });

--- a/web-extension/popup.css
+++ b/web-extension/popup.css
@@ -1,0 +1,8 @@
+li {
+    list-style: none;
+    margin: 0.5em 0;
+}
+
+ul {
+    padding: 0;
+}

--- a/web-extension/popup.html
+++ b/web-extension/popup.html
@@ -1,9 +1,12 @@
 <!DOCTYPE html>
-<html>
-
+<html lang="en">
+<head>
+    <meta charset=utf-8>
+    <title>OTP</title>
+</head>
 <body>
     <form id="getTotp">
-        <input id="totpKey" autocomplete="off"></input>
+        <input id="totpKey" autocomplete="one-time-code"/>
     </form>
     <span id="code"></span>
     <script src="popup.js"></script>

--- a/web-extension/popup.html
+++ b/web-extension/popup.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset=utf-8>
     <title>OTP</title>
+    <link rel="stylesheet" href="popup.css">
 </head>
 <body>
     <form id="getTotp">

--- a/web-extension/popup.html
+++ b/web-extension/popup.html
@@ -8,7 +8,9 @@
     <form id="getTotp">
         <input id="totpKey" autocomplete="one-time-code"/>
     </form>
+    <ul id="accounts"></ul>
     <span id="code"></span>
+    <span id="error"></span>
     <script src="popup.js"></script>
 </body>
 

--- a/web-extension/popup.html
+++ b/web-extension/popup.html
@@ -6,7 +6,7 @@
 </head>
 <body>
     <form id="getTotp">
-        <input id="totpKey" autocomplete="one-time-code"/>
+        <input id="totpKey" autocomplete="off"/>
     </form>
     <ul id="accounts"></ul>
     <span id="code"></span>

--- a/web-extension/popup.html
+++ b/web-extension/popup.html
@@ -11,6 +11,7 @@
     <ul id="accounts"></ul>
     <span id="code"></span>
     <span id="error"></span>
+    <span style="color: aqua" id="debug"></span>
     <script src="popup.js"></script>
 </body>
 

--- a/web-extension/popup.html
+++ b/web-extension/popup.html
@@ -11,7 +11,6 @@
     <ul id="accounts"></ul>
     <span id="code"></span>
     <span id="error"></span>
-    <span style="color: aqua" id="debug"></span>
     <script src="popup.js"></script>
 </body>
 

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -5,12 +5,8 @@ let state = {
     returnedKey: "",
     availableAccounts: {},
     error: undefined,
-    filterEntered: "",
-    debug: ""
+    filterEntered: ""
 }
-
-let nextStateUpdate = undefined
-let oldState = undefined
 
 const handleCodeResponse = (response) => {
     if (response.error) {
@@ -33,32 +29,14 @@ const handleAccountsResponse = (response) => {
     }
 }
 
-const commitNewStateAndRender = (oldState, newState) => {
-    debug("commit new state" +  JSON.stringify(newState));
-
+const setState = (newState) => {
+    const oldState = state;
     state = {
         ...state,
         ...newState,
     }
     render();
     componentsDidUpdate(oldState, state);
-}
-
-const setState = (newState) => {
-    debug("new state:" + JSON.stringify(newState));
-    if (nextStateUpdate === undefined) {
-        oldState = state;
-        setTimeout(() => {
-            commitNewStateAndRender(oldState, nextStateUpdate);
-            nextStateUpdate = undefined;
-        }, 100);
-    }
-    nextStateUpdate = { ...nextStateUpdate, ...newState };
-}
-
-const debug = (message) => {
-    state.debug = state.debug + "<br><br>" + message
-    document.getElementById('debug').innerHTML = state.debug
 }
 
 const componentsDidUpdate = (oldState, newState) => {
@@ -69,7 +47,6 @@ const componentsDidUpdate = (oldState, newState) => {
         selection.removeAllRanges();
         range.selectNodeContents(document.getElementById('code'));
         selection.addRange(range);
-        debug("Copied to clipboard");
     }
 }
 
@@ -92,7 +69,6 @@ const displayError = (error) => {
 const displayCode = (selectedKey) => {
     const node = document.getElementById('code');
     node.innerText = selectedKey;
-    debug("rendered displayed key")
 };
 
 const displayListOfAccounts = (accounts, selectedAccount) => {

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -1,6 +1,6 @@
 window.onload = () => document.getElementById('totpKey').focus();
 
-let state = {
+let globalState = {
     selectedAccount: "",
     returnedKey: "",
     availableAccounts: {},
@@ -32,13 +32,13 @@ const handleAccountsResponse = (response) => {
 }
 
 const setState = (newState) => {
-    oldState = state;
-    state = {
-        ...state,
+    oldState = globalState;
+    globalState = {
+        ...globalState,
         ...newState,
     }
-    render(state);
-    componentsDidUpdate(oldState, state);
+    render(globalState);
+    componentsDidUpdate(oldState, globalState);
 }
 
 const componentsDidUpdate = (oldState, newState) => {
@@ -55,7 +55,7 @@ const componentsDidUpdate = (oldState, newState) => {
 const render = (state) => {
     displayError(state.error);
     displayCode(state.returnedKey)
-    displayListOfAccounts(state.availableAccounts)
+    displayListOfAccounts(state.availableAccounts, state.filterEntered)
 }
 
 const displayError = (error) => {
@@ -74,12 +74,12 @@ const displayCode = (selectedKey) => {
     }
 };
 
-const displayListOfAccounts = (accounts, selectedAccount) => {
+const displayListOfAccounts = (accounts, filterEntered, selectedAccount) => {
     const node = document.getElementById('accounts');
 
     node.replaceChildren(
         ...Object.keys(accounts)
-            .filter(account => account.toLowerCase().includes(state.filterEntered.toLowerCase()))
+            .filter(account => account.toLowerCase().includes(filterEntered.toLowerCase()))
             .sort()
             .map(account => {
                 const li = document.createElement('li');

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -6,7 +6,6 @@ let state = {
     availableAccounts: {},
     error: undefined,
     filterEntered: "",
-    debug: ""
 }
 
 let nextStateUpdate = undefined
@@ -34,8 +33,6 @@ const handleAccountsResponse = (response) => {
 }
 
 const commitNewStateAndRender = (oldState, newState) => {
-    debug("commit new state" +  JSON.stringify(newState));
-
     state = {
         ...state,
         ...newState,
@@ -45,7 +42,6 @@ const commitNewStateAndRender = (oldState, newState) => {
 }
 
 const setState = (newState) => {
-    debug("new state:" + JSON.stringify(newState));
     if (nextStateUpdate === undefined) {
         oldState = state;
         setTimeout(() => {
@@ -56,11 +52,6 @@ const setState = (newState) => {
     nextStateUpdate = { ...nextStateUpdate, ...newState };
 }
 
-const debug = (message) => {
-    state.debug = state.debug + "<br><br>" + message
-    document.getElementById('debug').innerHTML = state.debug
-}
-
 const componentsDidUpdate = (oldState, newState) => {
     if (oldState.returnedKey !== newState.returnedKey) {
         const selection = window.getSelection();
@@ -69,7 +60,6 @@ const componentsDidUpdate = (oldState, newState) => {
         selection.removeAllRanges();
         range.selectNodeContents(document.getElementById('code'));
         selection.addRange(range);
-        debug("Copied to clipboard");
     }
 }
 
@@ -92,7 +82,6 @@ const displayError = (error) => {
 const displayCode = (selectedKey) => {
     const node = document.getElementById('code');
     node.innerText = selectedKey;
-    debug("rendered displayed key")
 };
 
 const displayListOfAccounts = (accounts, selectedAccount) => {

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -77,6 +77,7 @@ const displayListOfAccounts = (accounts, selectedAccount) => {
     node.replaceChildren(
         ...Object.keys(accounts)
             .filter(account => account.toLowerCase().includes(state.filterEntered.toLowerCase()))
+            .sort()
             .map(account => {
                 const li = document.createElement('li');
                 li.innerText = accounts[account];

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -1,10 +1,54 @@
 window.onload = () => document.getElementById('totpKey').focus();
 
-const displayResult = (result) => {
-  const node = document.getElementById('code');
+let state = {
+    selectedAccount: "",
+    returnedKey: "",
+    availableAccounts: {},
+    error: undefined,
+}
 
-  if (result.code) {
-    node.innerText = result.code;
+const handleCodeResponse = (response) => {
+    if (response.error) {
+        setState({ error: response.error });
+    } else {
+        setState({ error: undefined, returnedKey: response.code, selectedAccount: response.account });
+    }
+}
+const handleAccountsResponse = (response) => {
+    if (response.error) {
+        setState({ error: response.error });
+    } else {
+        setState({
+            error: undefined,
+            availableAccounts: response.accounts.reduce((accounts, account) => ({
+                ...accounts,
+                [account]: account
+            }), {})
+        });
+    }
+}
+
+const setState = (newState) => {
+    state = {
+        ...state,
+        ...newState,
+    }
+    render();
+}
+
+const render = () => {
+    if (state.error) {
+        document.getElementById('error').innerText = JSON.stringify(state)
+        return
+    }
+    displayCode(state.returnedKey)
+    displayListOfAccounts(state.availableAccounts)
+}
+
+
+const displayCode = (selectedKey) => {
+    const node = document.getElementById('code');
+    node.innerText = selectedKey;
 
     const selection = window.getSelection();
     const range = document.createRange();
@@ -12,17 +56,27 @@ const displayResult = (result) => {
     selection.removeAllRanges();
     range.selectNodeContents(node);
     selection.addRange(range);
-  } else {
-    node.innerText = JSON.stringify(result);
-  }
+};
+
+const displayListOfAccounts = (accounts, selectedAccount) => {
+    const node = document.getElementById('accounts');
+
+    node.replaceChildren(
+        ...Object.keys(accounts).map(account => {
+            const li = document.createElement('li');
+            li.innerText = accounts[account];
+            return li;
+        }));
 };
 
 document.getElementById('getTotp').addEventListener('submit', async (e) => {
-  e.preventDefault();
+    e.preventDefault();
 
-  const key = e.target.elements.totpKey.value;
+    const key = e.target.elements.totpKey.value;
 
-  document.getElementById('code').innerText = 'getting OTP ... (touch YubiKey?)';
+    document.getElementById('code').innerText = 'getting OTP ... (touch YubiKey?)';
 
-  chrome.runtime.sendMessage(key, displayResult);
+    chrome.runtime.sendMessage({ type: "getOtp", key }, handleCodeResponse);
 });
+
+chrome.runtime.sendMessage({ type: "getList" }, handleAccountsResponse);

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -5,8 +5,12 @@ let state = {
     returnedKey: "",
     availableAccounts: {},
     error: undefined,
-    filterEntered: ""
+    filterEntered: "",
+    debug: ""
 }
+
+let nextStateUpdate = undefined
+let oldState = undefined
 
 const handleCodeResponse = (response) => {
     if (response.error) {
@@ -29,14 +33,32 @@ const handleAccountsResponse = (response) => {
     }
 }
 
-const setState = (newState) => {
-    const oldState = state;
+const commitNewStateAndRender = (oldState, newState) => {
+    debug("commit new state" +  JSON.stringify(newState));
+
     state = {
         ...state,
         ...newState,
     }
     render();
     componentsDidUpdate(oldState, state);
+}
+
+const setState = (newState) => {
+    debug("new state:" + JSON.stringify(newState));
+    if (nextStateUpdate === undefined) {
+        oldState = state;
+        setTimeout(() => {
+            commitNewStateAndRender(oldState, nextStateUpdate);
+            nextStateUpdate = undefined;
+        }, 100);
+    }
+    nextStateUpdate = { ...nextStateUpdate, ...newState };
+}
+
+const debug = (message) => {
+    state.debug = state.debug + "<br><br>" + message
+    document.getElementById('debug').innerHTML = state.debug
 }
 
 const componentsDidUpdate = (oldState, newState) => {
@@ -47,6 +69,7 @@ const componentsDidUpdate = (oldState, newState) => {
         selection.removeAllRanges();
         range.selectNodeContents(document.getElementById('code'));
         selection.addRange(range);
+        debug("Copied to clipboard");
     }
 }
 
@@ -69,6 +92,7 @@ const displayError = (error) => {
 const displayCode = (selectedKey) => {
     const node = document.getElementById('code');
     node.innerText = selectedKey;
+    debug("rendered displayed key")
 };
 
 const displayListOfAccounts = (accounts, selectedAccount) => {

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -8,6 +8,8 @@ let state = {
     filterEntered: ""
 }
 
+let oldState = {}
+
 const handleCodeResponse = (response) => {
     if (response.error) {
         setState({ error: response.error });
@@ -30,12 +32,12 @@ const handleAccountsResponse = (response) => {
 }
 
 const setState = (newState) => {
-    const oldState = state;
+    oldState = state;
     state = {
         ...state,
         ...newState,
     }
-    render();
+    render(state);
     componentsDidUpdate(oldState, state);
 }
 
@@ -50,7 +52,7 @@ const componentsDidUpdate = (oldState, newState) => {
     }
 }
 
-const render = () => {
+const render = (state) => {
     displayError(state.error);
     displayCode(state.returnedKey)
     displayListOfAccounts(state.availableAccounts)
@@ -67,8 +69,9 @@ const displayError = (error) => {
 }
 
 const displayCode = (selectedKey) => {
-    const node = document.getElementById('code');
-    node.innerText = selectedKey;
+    if (oldState.returnedKey !== selectedKey) {
+        document.getElementById('code').innerText = selectedKey;
+    }
 };
 
 const displayListOfAccounts = (accounts, selectedAccount) => {

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -51,14 +51,20 @@ const componentsDidUpdate = (oldState, newState) => {
 }
 
 const render = () => {
-    if (state.error) {
-        document.getElementById('error').innerText = JSON.stringify(state)
-        return
-    }
+    displayError(state.error);
     displayCode(state.returnedKey)
     displayListOfAccounts(state.availableAccounts)
 }
 
+const displayError = (error) => {
+    if (!error) {
+        document.getElementById('error').innerText = '';
+    } else if (error.includes("NoMatchingCredential")) {
+        document.getElementById('error').innerText = "No matching credentials found.";
+    } else {
+        document.getElementById('error').innerText = error;
+    }
+}
 
 const displayCode = (selectedKey) => {
     const node = document.getElementById('code');
@@ -72,10 +78,10 @@ const displayListOfAccounts = (accounts, selectedAccount) => {
         ...Object.keys(accounts)
             .filter(account => account.toLowerCase().includes(state.filterEntered.toLowerCase()))
             .map(account => {
-            const li = document.createElement('li');
-            li.innerText = accounts[account];
-            return li;
-        }));
+                const li = document.createElement('li');
+                li.innerText = accounts[account];
+                return li;
+            }));
 };
 
 document.getElementById('getTotp').addEventListener('submit', async (e) => {

--- a/web-extension/popup.js
+++ b/web-extension/popup.js
@@ -6,6 +6,7 @@ let state = {
     availableAccounts: {},
     error: undefined,
     filterEntered: "",
+    debug: ""
 }
 
 let nextStateUpdate = undefined
@@ -33,6 +34,8 @@ const handleAccountsResponse = (response) => {
 }
 
 const commitNewStateAndRender = (oldState, newState) => {
+    debug("commit new state" +  JSON.stringify(newState));
+
     state = {
         ...state,
         ...newState,
@@ -42,6 +45,7 @@ const commitNewStateAndRender = (oldState, newState) => {
 }
 
 const setState = (newState) => {
+    debug("new state:" + JSON.stringify(newState));
     if (nextStateUpdate === undefined) {
         oldState = state;
         setTimeout(() => {
@@ -52,6 +56,11 @@ const setState = (newState) => {
     nextStateUpdate = { ...nextStateUpdate, ...newState };
 }
 
+const debug = (message) => {
+    state.debug = state.debug + "<br><br>" + message
+    document.getElementById('debug').innerHTML = state.debug
+}
+
 const componentsDidUpdate = (oldState, newState) => {
     if (oldState.returnedKey !== newState.returnedKey) {
         const selection = window.getSelection();
@@ -60,6 +69,7 @@ const componentsDidUpdate = (oldState, newState) => {
         selection.removeAllRanges();
         range.selectNodeContents(document.getElementById('code'));
         selection.addRange(range);
+        debug("Copied to clipboard");
     }
 }
 
@@ -82,6 +92,7 @@ const displayError = (error) => {
 const displayCode = (selectedKey) => {
     const node = document.getElementById('code');
     node.innerText = selectedKey;
+    debug("rendered displayed key")
 };
 
 const displayListOfAccounts = (accounts, selectedAccount) => {


### PR DESCRIPTION
The list is filtered down while typing the name. This helps a lot when using the extension.

The code is inspired a bit by React, but it's a little crude.
I had a throttled version of setState that would not render synchronously, but that turned out to be unnecessary (for now).

A lot of different improvements now come to mind:
* being able to choose a key with the arrow keys (that's what the `selectedAccount` state might be used for)
  * And thus being able to get an OTP while there are still multiple keys in the list
* "locking in" a key visually when there is only one left, to show that pressing Enter now will make good things happen
* showing an early error and not allowing the user to submit when there is no key left in the list
* displaying the OTPs in the list already if possible
* etc etc